### PR TITLE
Add --fail-on flag for CI vulnerability gating

### DIFF
--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -26,6 +26,7 @@ func init() {
 	pipelineCmd.Flags().Bool("sign", true, "sign the SBOM with Sigstore")
 	pipelineCmd.Flags().Bool("attest", true, "generate SLSA provenance attestation")
 	pipelineCmd.Flags().Bool("vex-triage", false, "run VEX triage against OSV.dev")
+	pipelineCmd.Flags().String("fail-on", "", "fail with exit code 2 if vulnerabilities at or above this severity: critical, high, medium, low")
 	pipelineCmd.Flags().Bool("include-dev", false, "include devDependencies")
 	pipelineCmd.Flags().String("identity-token", "", "explicit OIDC token for signing")
 }
@@ -45,6 +46,7 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 	doSign, _ := cmd.Flags().GetBool("sign")
 	doAttest, _ := cmd.Flags().GetBool("attest")
 	doVEXTriage, _ := cmd.Flags().GetBool("vex-triage")
+	failOn, _ := cmd.Flags().GetString("fail-on")
 	includeDev, _ := cmd.Flags().GetBool("include-dev")
 	identityToken, _ := cmd.Flags().GetString("identity-token")
 	quiet, _ := cmd.Flags().GetBool("quiet")
@@ -188,6 +190,11 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, "Step 3/4: Attestation skipped")
 	}
 
+	// Enable VEX triage automatically if --fail-on is set
+	if failOn != "" {
+		doVEXTriage = true
+	}
+
 	// Step 4: VEX triage
 	if doVEXTriage {
 		if !quiet {
@@ -210,6 +217,17 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 			if !quiet {
 				fmt.Fprintf(os.Stderr, "  VEX document written to %s\n", vexPath)
 				vex.PrintSummary(os.Stderr, triageResult)
+			}
+
+			// Check --fail-on threshold
+			if failOn != "" {
+				threshold, err := vex.ParseSeverityLevel(failOn)
+				if err != nil {
+					return err
+				}
+				if vex.ExceedsThreshold(triageResult, threshold) {
+					return &vex.ThresholdError{Threshold: threshold, Counts: triageResult.CountBySeverity}
+				}
 			}
 		}
 	} else if !quiet {

--- a/internal/cli/vex.go
+++ b/internal/cli/vex.go
@@ -39,6 +39,7 @@ func init() {
 	// Triage flags
 	vexTriageCmd.Flags().String("sbom", "", "path to SBOM")
 	vexTriageCmd.Flags().String("format", "openvex", "output format: openvex or cyclonedx")
+	vexTriageCmd.Flags().String("fail-on", "", "fail with exit code 2 if vulnerabilities at or above this severity: critical, high, medium, low")
 	_ = vexTriageCmd.MarkFlagRequired("sbom")
 }
 
@@ -167,6 +168,18 @@ var vexTriageCmd = &cobra.Command{
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		if !quiet {
 			vex.PrintSummary(os.Stderr, result)
+		}
+
+		// Check --fail-on threshold
+		failOn, _ := cmd.Flags().GetString("fail-on")
+		if failOn != "" {
+			threshold, err := vex.ParseSeverityLevel(failOn)
+			if err != nil {
+				return err
+			}
+			if vex.ExceedsThreshold(result, threshold) {
+				return &vex.ThresholdError{Threshold: threshold, Counts: result.CountBySeverity}
+			}
 		}
 
 		outputPath, _ := cmd.Flags().GetString("output")

--- a/internal/vex/summary.go
+++ b/internal/vex/summary.go
@@ -89,3 +89,69 @@ func PrintSummary(w io.Writer, result *TriageResult) {
 func PrintSummaryToStderr(result *TriageResult) {
 	PrintSummary(os.Stderr, result)
 }
+
+// severityRank returns a numeric rank for ordering (lower = more severe).
+func severityRank(sev SeverityLevel) int {
+	switch sev {
+	case SeverityCritical:
+		return 0
+	case SeverityHigh:
+		return 1
+	case SeverityMedium:
+		return 2
+	case SeverityLow:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// ParseSeverityLevel parses a string into a SeverityLevel.
+// Returns SeverityUnknown and an error for invalid input.
+func ParseSeverityLevel(s string) (SeverityLevel, error) {
+	switch strings.ToLower(s) {
+	case "critical":
+		return SeverityCritical, nil
+	case "high":
+		return SeverityHigh, nil
+	case "medium":
+		return SeverityMedium, nil
+	case "low":
+		return SeverityLow, nil
+	default:
+		return SeverityUnknown, fmt.Errorf("invalid severity level %q; valid values: critical, high, medium, low", s)
+	}
+}
+
+// ExceedsThreshold checks if any vulnerability in the result meets or exceeds
+// the given severity threshold. Returns true if the threshold is exceeded.
+func ExceedsThreshold(result *TriageResult, threshold SeverityLevel) bool {
+	thresholdRank := severityRank(threshold)
+	for _, sev := range severityOrder {
+		if severityRank(sev) <= thresholdRank {
+			if count, ok := result.CountBySeverity[sev]; ok && count > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ThresholdError is returned when vulnerabilities exceed the --fail-on threshold.
+type ThresholdError struct {
+	Threshold SeverityLevel
+	Counts    map[SeverityLevel]int
+}
+
+func (e *ThresholdError) Error() string {
+	parts := make([]string, 0)
+	thresholdRank := severityRank(e.Threshold)
+	for _, sev := range severityOrder {
+		if severityRank(sev) <= thresholdRank {
+			if count, ok := e.Counts[sev]; ok && count > 0 {
+				parts = append(parts, fmt.Sprintf("%d %s", count, sev))
+			}
+		}
+	}
+	return fmt.Sprintf("vulnerability threshold exceeded (%s): %s", e.Threshold, strings.Join(parts, ", "))
+}

--- a/internal/vex/threshold_test.go
+++ b/internal/vex/threshold_test.go
@@ -1,0 +1,147 @@
+package vex
+
+import "testing"
+
+func TestParseSeverityLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected SeverityLevel
+		wantErr  bool
+	}{
+		{"critical", SeverityCritical, false},
+		{"CRITICAL", SeverityCritical, false},
+		{"Critical", SeverityCritical, false},
+		{"high", SeverityHigh, false},
+		{"medium", SeverityMedium, false},
+		{"low", SeverityLow, false},
+		{"invalid", SeverityUnknown, true},
+		{"", SeverityUnknown, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSeverityLevel(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSeverityLevel(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ParseSeverityLevel(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExceedsThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		counts    map[SeverityLevel]int
+		threshold SeverityLevel
+		expected  bool
+	}{
+		{
+			name:      "critical threshold, has critical",
+			counts:    map[SeverityLevel]int{SeverityCritical: 1, SeverityHigh: 3},
+			threshold: SeverityCritical,
+			expected:  true,
+		},
+		{
+			name:      "critical threshold, only high",
+			counts:    map[SeverityLevel]int{SeverityHigh: 3, SeverityMedium: 5},
+			threshold: SeverityCritical,
+			expected:  false,
+		},
+		{
+			name:      "high threshold, has critical",
+			counts:    map[SeverityLevel]int{SeverityCritical: 1},
+			threshold: SeverityHigh,
+			expected:  true,
+		},
+		{
+			name:      "high threshold, has high",
+			counts:    map[SeverityLevel]int{SeverityHigh: 2, SeverityLow: 10},
+			threshold: SeverityHigh,
+			expected:  true,
+		},
+		{
+			name:      "high threshold, only medium and low",
+			counts:    map[SeverityLevel]int{SeverityMedium: 5, SeverityLow: 10},
+			threshold: SeverityHigh,
+			expected:  false,
+		},
+		{
+			name:      "medium threshold, has medium",
+			counts:    map[SeverityLevel]int{SeverityMedium: 3},
+			threshold: SeverityMedium,
+			expected:  true,
+		},
+		{
+			name:      "low threshold, has low",
+			counts:    map[SeverityLevel]int{SeverityLow: 1},
+			threshold: SeverityLow,
+			expected:  true,
+		},
+		{
+			name:      "low threshold, only unknown",
+			counts:    map[SeverityLevel]int{SeverityUnknown: 5},
+			threshold: SeverityLow,
+			expected:  false,
+		},
+		{
+			name:      "no vulns at all",
+			counts:    map[SeverityLevel]int{},
+			threshold: SeverityLow,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &TriageResult{CountBySeverity: tt.counts}
+			got := ExceedsThreshold(result, tt.threshold)
+			if got != tt.expected {
+				t.Errorf("ExceedsThreshold() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestThresholdErrorMessage(t *testing.T) {
+	err := &ThresholdError{
+		Threshold: SeverityHigh,
+		Counts: map[SeverityLevel]int{
+			SeverityCritical: 2,
+			SeverityHigh:     3,
+			SeverityMedium:   10,
+		},
+	}
+
+	msg := err.Error()
+	if msg == "" {
+		t.Fatal("expected non-empty error message")
+	}
+	// Should mention threshold
+	if !contains(msg, "high") {
+		t.Errorf("expected threshold in message, got: %s", msg)
+	}
+	// Should mention critical and high counts (at or above threshold)
+	if !contains(msg, "2 critical") {
+		t.Errorf("expected critical count in message, got: %s", msg)
+	}
+	if !contains(msg, "3 high") {
+		t.Errorf("expected high count in message, got: %s", msg)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add `--fail-on <severity>` flag to `vex triage` and `pipeline` commands
- When vulnerabilities at or above threshold are found, exit with error
- `--fail-on` on pipeline automatically enables `--vex-triage`
- Case insensitive parsing: critical, high, medium, low
- `ThresholdError` type with descriptive message showing which severities exceeded

## Usage
```bash
# Fail CI if any critical vulnerabilities
forgeseal pipeline --dir . --fail-on critical

# Fail if high or critical
forgeseal vex triage --sbom sbom.cdx.json --fail-on high
```

## Test plan
- [x] `TestParseSeverityLevel`: 8 cases including case variations and invalid input
- [x] `TestExceedsThreshold`: 9 cases covering all severity combinations
- [x] `TestThresholdErrorMessage`: validates error output format
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` full suite passes

Closes #1