### PR TITLE
Rewrite GitHub Action for Marketplace publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built for EU Cyber Resilience Act (CRA) compliance. forgeseal's own releases are
 | **SBOM Generation** | CycloneDX v1.4/v1.5/v1.6 from any JS/TS lockfile (JSON and XML output) |
 | **Sigstore Signing** | Keyless signing via Fulcio + Rekor transparency log (OIDC identity) |
 | **SLSA Provenance** | In-toto attestations with SLSA v1 provenance predicate |
-| **VEX Management** | OpenVEX v0.2 document CRUD, automated triage via OSV.dev |
+| **VEX Management** | OpenVEX v0.2 document CRUD, automated triage via OSV.dev, CVSS severity classification |
 | **Verification** | Validate signatures, bundles, and attestation integrity |
 | **Pipeline** | Single command: SBOM, sign, attest, triage |
 
@@ -154,7 +154,7 @@ forgeseal vex triage --sbom sbom.cdx.json --format cyclonedx -o sbom-with-vex.js
 
 **Justifications** (for `not_affected`): `component_not_present`, `vulnerable_code_not_present`, `vulnerable_code_cannot_be_controlled_by_adversary`, `vulnerable_code_not_in_execute_path`, `inline_mitigations_already_exist`
 
-The `triage` subcommand queries the [OSV.dev](https://osv.dev) batch API, batching PURLs in groups of 1000, and generates `under_investigation` stubs for each discovered vulnerability.
+The `triage` subcommand queries the [OSV.dev](https://osv.dev) batch API, batching PURLs in groups of 1000, classifies each vulnerability by CVSS severity (critical, high, medium, low), and generates `under_investigation` stubs for each discovered vulnerability. Use `--fail-on <severity>` to fail the command when vulnerabilities at or above the threshold are found.
 
 ### `forgeseal verify`
 
@@ -190,8 +190,11 @@ forgeseal pipeline --dir . --vex-triage --identity-token $TOKEN
 | `--sign` | `true` | Sign artifacts with Sigstore |
 | `--attest` | `true` | Generate SLSA provenance |
 | `--vex-triage` | `false` | Run VEX triage against OSV.dev |
+| `--fail-on` | (none) | Fail if vulnerabilities at or above severity: `critical`, `high`, `medium`, `low` |
 | `--include-dev` | `false` | Include devDependencies |
 | `--identity-token` | (auto) | Explicit OIDC token |
+
+Setting `--fail-on` automatically enables VEX triage.
 
 **Pipeline steps:**
 1. Parse lockfile, generate CycloneDX SBOM (`sbom.cdx.json`)
@@ -199,7 +202,31 @@ forgeseal pipeline --dir . --vex-triage --identity-token $TOKEN
 3. Generate SLSA provenance attestation (`sbom.cdx.json.intoto.jsonl`), optionally sign it
 4. Query OSV.dev and generate VEX document (`vex.json`)
 
+**Vulnerability summary:** When VEX triage runs, forgeseal prints a severity breakdown to stderr:
+
+```
+  🔴 CRITICAL 2 CRITICAL   🟡 HIGH 5 HIGH   🟠 MEDIUM 12 MEDIUM   ⚪ LOW 3 LOW
+
+  CRITICAL:
+    lodash@4.17.20                 Prototype Pollution                          CVE-2021-23337
+    express@4.17.1                 Path Traversal                               CVE-2024-29041
+
+  Scanned 156 components, found 42 vulnerabilities
+```
+
+**CI gating:** Use `--fail-on` to block builds when vulnerabilities exceed a threshold:
+
+```bash
+# Fail if any critical or high vulnerabilities found
+forgeseal pipeline --dir . --fail-on high
+
+# Fail only on critical
+forgeseal pipeline --dir . --fail-on critical
+```
+
 ## GitHub Action
+
+Available on the [GitHub Marketplace](https://github.com/marketplace/actions/forgeseal).
 
 ```yaml
 name: Supply Chain Security
@@ -215,14 +242,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: sn45/forgeseal@v1
+      - uses: sns45/forgeseal@v1
+        id: forgeseal
         with:
-          command: pipeline
           dir: '.'
-          output-dir: './forgeseal-output'
-          sign: 'true'
-          attest: 'true'
-          vex-triage: 'true'
+          fail-on: high  # Fail CI if high or critical vulnerabilities found
 
       - uses: actions/upload-artifact@v4
         with:
@@ -230,7 +254,31 @@ jobs:
           path: ./forgeseal-output/
 ```
 
-The action runs in a Docker container and automatically obtains OIDC tokens from the GitHub Actions runtime.
+### Action Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `command` | `pipeline` | Command to run: `pipeline`, `sbom`, `sign`, `attest`, `vex` |
+| `dir` | `.` | Project directory |
+| `output-dir` | `./forgeseal-output` | Output directory for artifacts |
+| `sign` | `true` | Sign artifacts with Sigstore keyless signing |
+| `attest` | `true` | Generate SLSA v1 provenance attestation |
+| `vex-triage` | `true` | Run VEX vulnerability triage against OSV.dev |
+| `fail-on` | (none) | Fail if vulnerabilities at or above severity: `critical`, `high`, `medium`, `low` |
+| `include-dev` | `false` | Include devDependencies in SBOM |
+| `version` | `latest` | forgeseal version to install |
+
+### Action Outputs
+
+| Output | Description |
+|---|---|
+| `sbom-path` | Path to the generated CycloneDX SBOM |
+| `bundle-path` | Path to the Sigstore signature bundle |
+| `attestation-path` | Path to the SLSA provenance attestation |
+| `vex-path` | Path to the VEX document |
+| `vuln-count` | Number of vulnerabilities found by VEX triage |
+
+The action downloads a pre-built binary from GitHub Releases (no Docker build overhead). OIDC tokens are obtained automatically when the workflow has `permissions: id-token: write`.
 
 ## Configuration
 
@@ -279,7 +327,7 @@ internal/
 
 **Signing abstraction.** The `Signer` interface provides `SignBlob` (raw content) and `SignDSSE` (in-toto envelope). The current implementation generates ephemeral ECDSA P-256 signatures. Full Sigstore integration (Fulcio certificate issuance + Rekor log recording) can be added by depending on `sigstore-go` without changing the interface.
 
-**VEX triage.** PURLs extracted from the SBOM are batched in groups of 1000 and sent to the OSV.dev `/v1/querybatch` endpoint. Results are mapped to `under_investigation` VEX stubs for manual review.
+**VEX triage.** PURLs extracted from the SBOM are batched in groups of 1000 and sent to the OSV.dev `/v1/querybatch` endpoint. Each vulnerability is classified by CVSS v3 severity (critical 9.0+, high 7.0+, medium 4.0+, low 0.1+). Results are mapped to VEX stubs with severity metadata. The `--fail-on` flag enables CI gating by exiting non-zero when vulnerabilities meet or exceed the specified threshold.
 
 ## Output Artifacts
 

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,16 @@
 name: 'forgeseal'
-description: 'Supply chain security for JS/TS projects: SBOM, Sigstore signing, SLSA provenance, VEX'
+description: 'Supply chain security for JS/TS: SBOM generation, Sigstore signing, SLSA provenance, VEX triage'
+author: 'sns45'
+
 branding:
   icon: 'shield'
   color: 'blue'
 
 inputs:
   command:
-    description: 'Command to run: sbom, sign, attest, vex, pipeline'
-    required: true
-    default: 'pipeline'
-  lockfile:
-    description: 'Explicit path to lockfile'
+    description: 'Command to run: pipeline, sbom, sign, attest, vex'
     required: false
+    default: 'pipeline'
   dir:
     description: 'Project directory'
     required: false
@@ -20,52 +19,165 @@ inputs:
     description: 'Output directory for artifacts'
     required: false
     default: './forgeseal-output'
+  lockfile:
+    description: 'Explicit path to lockfile (auto-detected if omitted)'
+    required: false
+  sign:
+    description: 'Sign artifacts with Sigstore keyless signing'
+    required: false
+    default: 'true'
+  attest:
+    description: 'Generate SLSA v1 provenance attestation'
+    required: false
+    default: 'true'
+  vex-triage:
+    description: 'Run VEX vulnerability triage against OSV.dev'
+    required: false
+    default: 'true'
+  fail-on:
+    description: 'Fail if vulnerabilities at or above this severity: critical, high, medium, low'
+    required: false
   include-dev:
     description: 'Include devDependencies in SBOM'
     required: false
     default: 'false'
-  sign:
-    description: 'Sign artifacts with Sigstore'
-    required: false
-    default: 'true'
-  attest:
-    description: 'Generate SLSA provenance attestation'
-    required: false
-    default: 'true'
-  vex-triage:
-    description: 'Run VEX triage against OSV.dev'
-    required: false
-    default: 'false'
   upload-assets:
-    description: 'Upload artifacts to GitHub Release'
+    description: 'Upload artifacts to the GitHub Release (requires release context)'
     required: false
     default: 'false'
   version:
-    description: 'forgeseal version to use'
+    description: 'forgeseal version to install (e.g. 0.1.0). Defaults to latest release.'
     required: false
     default: 'latest'
 
 outputs:
   sbom-path:
-    description: 'Path to generated SBOM'
+    description: 'Path to the generated CycloneDX SBOM'
+    value: ${{ steps.run.outputs.sbom-path }}
   bundle-path:
-    description: 'Path to Sigstore bundle'
+    description: 'Path to the Sigstore signature bundle'
+    value: ${{ steps.run.outputs.bundle-path }}
   attestation-path:
-    description: 'Path to SLSA attestation'
+    description: 'Path to the SLSA provenance attestation'
+    value: ${{ steps.run.outputs.attestation-path }}
   vex-path:
-    description: 'Path to VEX document'
+    description: 'Path to the VEX document'
+    value: ${{ steps.run.outputs.vex-path }}
+  vuln-count:
+    description: 'Number of vulnerabilities found by VEX triage'
+    value: ${{ steps.run.outputs.vuln-count }}
 
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    - ${{ inputs.command }}
-    - '--dir'
-    - ${{ inputs.dir }}
-    - '--output-dir'
-    - ${{ inputs.output-dir }}
-  env:
-    FORGESEAL_INCLUDE_DEV: ${{ inputs.include-dev }}
-    FORGESEAL_SIGN: ${{ inputs.sign }}
-    FORGESEAL_ATTEST: ${{ inputs.attest }}
-    FORGESEAL_VEX_TRIAGE: ${{ inputs.vex-triage }}
+  using: 'composite'
+  steps:
+    - name: Install forgeseal
+      id: install
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        VERSION="${{ inputs.version }}"
+        REPO="sns45/forgeseal"
+
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+          if [ -z "$VERSION" ]; then
+            VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+          fi
+        fi
+
+        # Strip leading v
+        VERSION="${VERSION#v}"
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+        OS="linux"
+        ARCH="$(uname -m)"
+        case "$ARCH" in
+          x86_64)  ARCH="amd64" ;;
+          aarch64) ARCH="arm64" ;;
+        esac
+
+        TARBALL="forgeseal_${VERSION}_${OS}_${ARCH}.tar.gz"
+        URL="https://github.com/${REPO}/releases/download/v${VERSION}/${TARBALL}"
+
+        echo "Downloading forgeseal v${VERSION} (${OS}/${ARCH})..."
+        curl -fsSL "$URL" -o "/tmp/${TARBALL}"
+        tar -xzf "/tmp/${TARBALL}" -C /tmp
+        chmod +x /tmp/forgeseal
+        sudo mv /tmp/forgeseal /usr/local/bin/forgeseal
+
+        echo "Installed forgeseal v${VERSION}"
+        forgeseal version
+
+    - name: Run forgeseal
+      id: run
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        COMMAND="${{ inputs.command }}"
+        DIR="${{ inputs.dir }}"
+        OUTPUT_DIR="${{ inputs.output-dir }}"
+
+        # Build argument list
+        ARGS=("$COMMAND")
+
+        if [ "$COMMAND" = "pipeline" ]; then
+          ARGS+=("--dir" "$DIR" "--output-dir" "$OUTPUT_DIR")
+
+          if [ "${{ inputs.sign }}" = "false" ]; then
+            ARGS+=("--sign=false")
+          fi
+          if [ "${{ inputs.attest }}" = "false" ]; then
+            ARGS+=("--attest=false")
+          fi
+          if [ "${{ inputs.vex-triage }}" = "true" ]; then
+            ARGS+=("--vex-triage")
+          fi
+          if [ -n "${{ inputs.fail-on }}" ]; then
+            ARGS+=("--fail-on" "${{ inputs.fail-on }}")
+          fi
+          if [ "${{ inputs.include-dev }}" = "true" ]; then
+            ARGS+=("--include-dev")
+          fi
+          if [ -n "${{ inputs.lockfile }}" ]; then
+            ARGS+=("--lockfile" "${{ inputs.lockfile }}")
+          fi
+        fi
+
+        echo "Running: forgeseal ${ARGS[*]}"
+        forgeseal "${ARGS[@]}"
+
+        # Set outputs
+        if [ -f "${OUTPUT_DIR}/sbom.cdx.json" ]; then
+          echo "sbom-path=${OUTPUT_DIR}/sbom.cdx.json" >> "$GITHUB_OUTPUT"
+        fi
+        if [ -f "${OUTPUT_DIR}/sbom.cdx.json.sigstore.json" ]; then
+          echo "bundle-path=${OUTPUT_DIR}/sbom.cdx.json.sigstore.json" >> "$GITHUB_OUTPUT"
+        fi
+        if [ -f "${OUTPUT_DIR}/sbom.cdx.json.intoto.jsonl" ]; then
+          echo "attestation-path=${OUTPUT_DIR}/sbom.cdx.json.intoto.jsonl" >> "$GITHUB_OUTPUT"
+        fi
+        if [ -f "${OUTPUT_DIR}/vex.json" ]; then
+          echo "vex-path=${OUTPUT_DIR}/vex.json" >> "$GITHUB_OUTPUT"
+          # Extract vuln count from VEX document
+          VULN_COUNT=$(jq '.statements | length' "${OUTPUT_DIR}/vex.json" 2>/dev/null || echo "0")
+          echo "vuln-count=${VULN_COUNT}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Upload artifacts to release
+      if: inputs.upload-assets == 'true' && github.event_name == 'release'
+      shell: bash
+      run: |
+        set -euo pipefail
+        OUTPUT_DIR="${{ inputs.output-dir }}"
+        TAG="${{ github.event.release.tag_name }}"
+
+        for file in "${OUTPUT_DIR}"/*; do
+          if [ -f "$file" ]; then
+            echo "Uploading $(basename "$file") to release ${TAG}..."
+            gh release upload "$TAG" "$file" --clobber
+          fi
+        done
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Convert `action.yml` from Docker to composite action (downloads pre-built binary, no build overhead)
- Add `fail-on` input for CI vulnerability gating
- Add `vuln-count` output for conditional workflow steps
- Default `vex-triage` to `true`
- Set all outputs via `$GITHUB_OUTPUT` (sbom-path, bundle-path, attestation-path, vex-path)
- Add release upload step for `upload-assets: true`
- Update README with `--fail-on` docs, severity summary example, refreshed Action section

## Usage after merge
```yaml
- uses: sns45/forgeseal@v1
  with:
    fail-on: high
```

## Test plan
- [x] `action.yml` validates as valid YAML
- [x] README renders correctly with new sections
- [x] All inputs/outputs documented in both action.yml and README

## Next step
After merging, publish to GitHub Marketplace via "Draft a release" with the marketplace checkbox.

Closes #7