### PR TITLE
Add Java/Gradle gradle.lockfile support

### DIFF
--- a/internal/lockfile/gradle.go
+++ b/internal/lockfile/gradle.go
@@ -1,0 +1,74 @@
+package lockfile
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+)
+
+// GradleParser handles Gradle dependency lockfiles (gradle.lockfile).
+type GradleParser struct{}
+
+func (p *GradleParser) Type() LockfileType  { return TypeGradleLock }
+func (p *GradleParser) Filenames() []string { return []string{"gradle.lockfile"} }
+
+func (p *GradleParser) Parse(ctx context.Context, r io.Reader) (*LockfileResult, error) {
+	result := &LockfileResult{Type: TypeGradleLock}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Lines like "empty=..." list configurations with no dependencies; skip.
+		if strings.HasPrefix(line, "empty=") {
+			continue
+		}
+
+		eqIdx := strings.LastIndex(line, "=")
+		if eqIdx < 0 {
+			continue
+		}
+		coord := line[:eqIdx]
+		configs := line[eqIdx+1:]
+
+		parts := strings.Split(coord, ":")
+		if len(parts) != 3 {
+			continue
+		}
+		group, artifact, version := parts[0], parts[1], parts[2]
+		if group == "" || artifact == "" || version == "" {
+			continue
+		}
+
+		result.Packages = append(result.Packages, Package{
+			Name:    group + ":" + artifact,
+			Version: version,
+			Dev:     isGradleTestOnly(configs),
+		})
+	}
+
+	return result, scanner.Err()
+}
+
+// isGradleTestOnly returns true when every configuration in the CSV starts
+// with "test" (case-insensitive). Empty input returns false.
+func isGradleTestOnly(configs string) bool {
+	configs = strings.TrimSpace(configs)
+	if configs == "" {
+		return false
+	}
+	for _, c := range strings.Split(configs, ",") {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		if !strings.HasPrefix(strings.ToLower(c), "test") {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/lockfile/gradle_test.go
+++ b/internal/lockfile/gradle_test.go
@@ -1,0 +1,85 @@
+package lockfile
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestGradleParser(t *testing.T) {
+	f, err := os.Open("../../testdata/lockfiles/gradle/gradle.lockfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	parser := &GradleParser{}
+	result, err := parser.Parse(context.Background(), f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Type != TypeGradleLock {
+		t.Errorf("expected type %s, got %s", TypeGradleLock, result.Type)
+	}
+
+	if len(result.Packages) != 10 {
+		t.Fatalf("expected 10 packages, got %d", len(result.Packages))
+	}
+
+	found := make(map[string]Package)
+	for _, pkg := range result.Packages {
+		found[pkg.Name] = pkg
+	}
+
+	// Coordinate format: group:artifact.
+	if pkg, ok := found["org.springframework:spring-core"]; !ok {
+		t.Error("missing spring-core")
+	} else if pkg.Version != "6.1.2" {
+		t.Errorf("spring-core version: got %s, want 6.1.2", pkg.Version)
+	}
+
+	// Production dep should not be dev.
+	if pkg := found["com.google.guava:guava"]; pkg.Dev {
+		t.Error("guava should not be marked dev")
+	}
+
+	// Test-only deps should be Dev=true.
+	if pkg, ok := found["org.junit.jupiter:junit-jupiter-api"]; !ok {
+		t.Error("missing junit-jupiter-api")
+	} else if !pkg.Dev {
+		t.Error("junit-jupiter-api should be marked dev")
+	}
+	if pkg := found["org.mockito:mockito-core"]; !pkg.Dev {
+		t.Error("mockito-core should be marked dev")
+	}
+}
+
+func TestGradleDevDetection(t *testing.T) {
+	tests := []struct {
+		configs string
+		want    bool
+	}{
+		{"compileClasspath,runtimeClasspath", false},
+		{"testCompileClasspath,testRuntimeClasspath", true},
+		{"compileClasspath,testCompileClasspath", false},
+		{"testImplementation", true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isGradleTestOnly(tt.configs)
+		if got != tt.want {
+			t.Errorf("isGradleTestOnly(%q) = %v, want %v", tt.configs, got, tt.want)
+		}
+	}
+}
+
+func TestGradleParserType(t *testing.T) {
+	p := &GradleParser{}
+	if p.Type() != TypeGradleLock {
+		t.Errorf("expected %s, got %s", TypeGradleLock, p.Type())
+	}
+	if fnames := p.Filenames(); len(fnames) != 1 || fnames[0] != "gradle.lockfile" {
+		t.Errorf("unexpected filenames: %v", fnames)
+	}
+}

--- a/internal/lockfile/model.go
+++ b/internal/lockfile/model.go
@@ -16,6 +16,7 @@ const (
 	TypeUV              LockfileType = "uv"
 	TypeGoMod           LockfileType = "gomod"
 	TypeCargoLock       LockfileType = "cargo"
+	TypeGradleLock      LockfileType = "gradle"
 )
 
 // Package represents a resolved dependency from a lockfile.

--- a/internal/lockfile/parser.go
+++ b/internal/lockfile/parser.go
@@ -51,6 +51,8 @@ func init() {
 		&GoModParser{},
 		// Rust
 		&CargoParser{},
+		// Java/Gradle
+		&GradleParser{},
 	}
 }
 

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -13,9 +13,16 @@ import (
 func mapComponent(pkg lockfile.Package, ecosystem string) cdx.Component {
 	purl := BuildPURL(pkg.Name, pkg.Version, ecosystem)
 
+	displayName := pkg.Name
+	if ecosystem == "maven" {
+		if idx := strings.Index(pkg.Name, ":"); idx > 0 {
+			displayName = pkg.Name[idx+1:]
+		}
+	}
+
 	comp := cdx.Component{
 		Type:    cdx.ComponentTypeLibrary,
-		Name:    pkg.Name,
+		Name:    displayName,
 		Version: pkg.Version,
 		BOMRef:  purl,
 		PackageURL: purl,
@@ -35,6 +42,8 @@ func mapComponent(pkg lockfile.Package, ecosystem string) cdx.Component {
 		registryURL = "https://pkg.go.dev/" + pkg.Name
 	case "cargo":
 		registryURL = "https://crates.io/crates/" + pkg.Name
+	case "maven":
+		registryURL = mavenRegistryURL(pkg.Name)
 	default:
 		registryURL = npmRegistryURL(pkg.Name)
 	}
@@ -101,6 +110,15 @@ func parseIntegrityHashes(integrity string) *[]cdx.Hash {
 // npmRegistryURL returns the npm registry URL for a package.
 func npmRegistryURL(name string) string {
 	return "https://www.npmjs.com/package/" + name
+}
+
+// mavenRegistryURL returns the Sonatype Central URL for a "group:artifact" coordinate.
+func mavenRegistryURL(name string) string {
+	parts := strings.SplitN(name, ":", 2)
+	if len(parts) != 2 {
+		return "https://central.sonatype.com/artifact/" + name
+	}
+	return "https://central.sonatype.com/artifact/" + parts[0] + "/" + parts[1]
 }
 
 // hashContent computes SHA-256 of the given content.

--- a/internal/sbom/generator.go
+++ b/internal/sbom/generator.go
@@ -43,6 +43,8 @@ func ecosystemFromLockfileType(lt lockfile.LockfileType) string {
 		return "golang"
 	case lockfile.TypeCargoLock:
 		return "cargo"
+	case lockfile.TypeGradleLock:
+		return "maven"
 	default:
 		return "npm"
 	}

--- a/internal/sbom/purl.go
+++ b/internal/sbom/purl.go
@@ -17,6 +17,8 @@ func BuildPURL(name, version, ecosystem string) string {
 		return BuildGolangPURL(name, version)
 	case "cargo":
 		return BuildCargoPURL(name, version)
+	case "maven":
+		return BuildMavenPURL(name, version)
 	default:
 		return BuildNPMPURL(name, version)
 	}
@@ -25,6 +27,20 @@ func BuildPURL(name, version, ecosystem string) string {
 // BuildCargoPURL constructs a Package URL for a Rust crate.
 func BuildCargoPURL(name, version string) string {
 	purl := packageurl.NewPackageURL("cargo", "", name, version, nil, "")
+	return purl.ToString()
+}
+
+// BuildMavenPURL constructs a Package URL for a Maven artifact.
+// The input `name` is expected to be "group:artifact".
+func BuildMavenPURL(name, version string) string {
+	var group, artifact string
+	if idx := strings.Index(name, ":"); idx > 0 {
+		group = name[:idx]
+		artifact = name[idx+1:]
+	} else {
+		artifact = name
+	}
+	purl := packageurl.NewPackageURL("maven", group, artifact, version, nil, "")
 	return purl.ToString()
 }
 

--- a/internal/sbom/purl_test.go
+++ b/internal/sbom/purl_test.go
@@ -28,6 +28,9 @@ func TestBuildPURL(t *testing.T) {
 		// Cargo crates
 		{"serde", "1.0.124", "cargo", "pkg:cargo/serde@1.0.124"},
 		{"tokio", "1.36.0", "cargo", "pkg:cargo/tokio@1.36.0"},
+		// Maven (group:artifact in name)
+		{"org.apache.logging.log4j:log4j-core", "2.14.1", "maven", "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"},
+		{"com.google.guava:guava", "32.1.3-jre", "maven", "pkg:maven/com.google.guava/guava@32.1.3-jre"},
 	}
 
 	for _, tt := range tests {

--- a/internal/sbom/snapshot_test.go
+++ b/internal/sbom/snapshot_test.go
@@ -127,7 +127,7 @@ func discoverSnapshotCases(t *testing.T) []snapshotCase {
 	knownFiles := []string{
 		"bun.lock", "pnpm-lock.yaml", "yarn.lock", "package-lock.json",
 		"uv.lock", "poetry.lock", "pdm.lock", "requirements.txt",
-		"go.mod", "Cargo.lock",
+		"go.mod", "Cargo.lock", "gradle.lockfile",
 	}
 
 	var cases []snapshotCase

--- a/testdata/lockfiles/gradle/gradle.lockfile
+++ b/testdata/lockfiles/gradle/gradle.lockfile
@@ -1,0 +1,14 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.google.guava:guava:32.1.3-jre=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.apache.commons:commons-lang3:3.13.0=compileClasspath,runtimeClasspath
+org.slf4j:slf4j-api:2.0.9=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.springframework:spring-core:6.1.2=compileClasspath,runtimeClasspath
+org.springframework:spring-context:6.1.2=compileClasspath,runtimeClasspath
+ch.qos.logback:logback-classic:1.4.14=runtimeClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.mockito:mockito-core:5.8.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,testAnnotationProcessor

--- a/testdata/snapshots/gradle.sbom.json
+++ b/testdata/snapshots/gradle.sbom.json
@@ -1,0 +1,204 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:00000000-0000-0000-0000-000000000000",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-01T00:00:00Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "name": "forgeseal",
+          "version": "snapshot-test"
+        }
+      ]
+    },
+    "component": {
+      "bom-ref": "pkg:maven/unknown@0.0.0",
+      "type": "application",
+      "name": "unknown",
+      "version": "0.0.0",
+      "purl": "pkg:maven/unknown@0.0.0"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.4.14",
+      "type": "library",
+      "name": "logback-classic",
+      "version": "1.4.14",
+      "purl": "pkg:maven/ch.qos.logback/logback-classic@1.4.14",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/ch.qos.logback/logback-classic",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.3",
+      "type": "library",
+      "name": "jackson-core",
+      "version": "2.15.3",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.3",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-core",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.guava/guava@32.1.3-jre",
+      "type": "library",
+      "name": "guava",
+      "version": "32.1.3-jre",
+      "purl": "pkg:maven/com.google.guava/guava@32.1.3-jre",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/com.google.guava/guava",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.13.0",
+      "type": "library",
+      "name": "commons-lang3",
+      "version": "3.13.0",
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.13.0",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.apache.commons/commons-lang3",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.10.1",
+      "type": "library",
+      "name": "junit-jupiter-api",
+      "version": "5.10.1",
+      "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.10.1",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.junit.jupiter/junit-jupiter-api",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.10.1",
+      "type": "library",
+      "name": "junit-jupiter-engine",
+      "version": "5.10.1",
+      "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.10.1",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.junit.jupiter/junit-jupiter-engine",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.mockito/mockito-core@5.8.0",
+      "type": "library",
+      "name": "mockito-core",
+      "version": "5.8.0",
+      "purl": "pkg:maven/org.mockito/mockito-core@5.8.0",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.mockito/mockito-core",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@2.0.9",
+      "type": "library",
+      "name": "slf4j-api",
+      "version": "2.0.9",
+      "purl": "pkg:maven/org.slf4j/slf4j-api@2.0.9",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.slf4j/slf4j-api",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.springframework/spring-context@6.1.2",
+      "type": "library",
+      "name": "spring-context",
+      "version": "6.1.2",
+      "purl": "pkg:maven/org.springframework/spring-context@6.1.2",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.springframework/spring-context",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.springframework/spring-core@6.1.2",
+      "type": "library",
+      "name": "spring-core",
+      "version": "6.1.2",
+      "purl": "pkg:maven/org.springframework/spring-core@6.1.2",
+      "externalReferences": [
+        {
+          "url": "https://central.sonatype.com/artifact/org.springframework/spring-core",
+          "type": "distribution"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:maven/ch.qos.logback/logback-classic@1.4.14"
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.3"
+    },
+    {
+      "ref": "pkg:maven/com.google.guava/guava@32.1.3-jre"
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-lang3@3.13.0"
+    },
+    {
+      "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.10.1"
+    },
+    {
+      "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.10.1"
+    },
+    {
+      "ref": "pkg:maven/org.mockito/mockito-core@5.8.0"
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/slf4j-api@2.0.9"
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-context@6.1.2"
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-core@6.1.2"
+    },
+    {
+      "ref": "pkg:maven/unknown@0.0.0",
+      "dependsOn": [
+        "pkg:maven/ch.qos.logback/logback-classic@1.4.14",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.3",
+        "pkg:maven/com.google.guava/guava@32.1.3-jre",
+        "pkg:maven/org.apache.commons/commons-lang3@3.13.0",
+        "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.10.1",
+        "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.10.1",
+        "pkg:maven/org.mockito/mockito-core@5.8.0",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.9",
+        "pkg:maven/org.springframework/spring-context@6.1.2",
+        "pkg:maven/org.springframework/spring-core@6.1.2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `GradleParser` for line-oriented `gradle.lockfile` entries (`group:artifact:version=configurations`)
- Dev detection: deps whose configurations are all `test*` prefixed → `Dev=true`
- Adds `BuildMavenPURL` producing `pkg:maven/group/artifact@version` PURLs
- CycloneDX: Sonatype Central external references, artifact-only display names
- Fixture with real Maven coordinates including test-only deps
- Snapshot test auto-generated

Closes #13. Rebased onto main after #19 merged (replaces #17).

## Test plan
- [x] `go test ./internal/lockfile/ -run TestGradle`
- [x] `go test ./internal/sbom/ -run TestSnapshots/gradle`
- [x] `go test -race -count=1 ./...`