### PR TITLE
Integrate Go/Rust/Gradle support: docs, tests, CLI polish

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/sns45/forgeseal"
-    description: "Supply chain security for JavaScript and TypeScript projects"
+    description: "Supply chain security for JavaScript, TypeScript, Python, Go, Rust, and Java projects"
     license: "Apache-2.0"
     install: |
       bin.install "forgeseal"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # forgeseal
 
-Supply chain security for JavaScript, TypeScript, and Python projects. Generates CycloneDX SBOMs from lockfiles, signs them with Sigstore (keyless), produces SLSA provenance attestations, and manages VEX vulnerability documents.
+Supply chain security for JavaScript, TypeScript, Python, Go, Rust, and Java/Gradle projects. Generates CycloneDX SBOMs from lockfiles, signs them with Sigstore (keyless), produces SLSA provenance attestations, and manages VEX vulnerability documents.
 
 Built for EU Cyber Resilience Act (CRA) compliance. forgeseal's own releases are attested by forgeseal.
 
@@ -8,7 +8,7 @@ Built for EU Cyber Resilience Act (CRA) compliance. forgeseal's own releases are
 
 | Capability | Description |
 |---|---|
-| **SBOM Generation** | CycloneDX v1.4/v1.5/v1.6 from any JS/TS/Python lockfile (JSON and XML output) |
+| **SBOM Generation** | CycloneDX v1.4/v1.5/v1.6 from any JS/TS, Python, Go, Rust, or Java/Gradle lockfile (JSON and XML output) |
 | **Sigstore Signing** | Keyless signing via Fulcio + Rekor transparency log (OIDC identity) |
 | **SLSA Provenance** | In-toto attestations with SLSA v1 provenance predicate |
 | **VEX Management** | OpenVEX v0.2 document CRUD, automated triage via OSV.dev, CVSS severity classification |
@@ -29,8 +29,11 @@ Built for EU Cyber Resilience Act (CRA) compliance. forgeseal's own releases are
 | Poetry | `poetry.lock` | TOML v2 format with full dependency graph |
 | PDM | `pdm.lock` | TOML format with groups based dev detection |
 | uv | `uv.lock` | TOML format (Astral uv v0.1+) |
+| Go modules | `go.mod` + `go.sum` | Parses require/replace directives and pairs with `h1:` hashes |
+| Cargo | `Cargo.lock` | TOML v3 format with SHA-256 checksums; skips workspace roots |
+| Gradle | `gradle.lockfile` | Line-oriented `group:artifact:version=configurations` with test-only dev detection |
 
-Detection priority: `bun.lockb` > `bun.lock` > `pnpm-lock.yaml` > `yarn.lock` > `package-lock.json` > `uv.lock` > `poetry.lock` > `pdm.lock` > `requirements.txt`. JS/TS lockfiles take precedence in mixed projects. Among Python lockfiles, uv.lock is preferred (most precise), followed by poetry.lock, pdm.lock, and requirements.txt (least precise). Yarn v1 vs Berry is determined by content inspection.
+Detection priority: `bun.lockb` > `bun.lock` > `pnpm-lock.yaml` > `yarn.lock` > `package-lock.json` > `uv.lock` > `poetry.lock` > `pdm.lock` > `requirements.txt` > `go.mod` > `Cargo.lock` > `gradle.lockfile`. JS/TS > Python > Go > Rust > Java. Among Python lockfiles, uv.lock is preferred (most precise), followed by poetry.lock, pdm.lock, and requirements.txt (least precise). Yarn v1 vs Berry is determined by content inspection.
 
 **Note on Yarn Berry hashes:** Yarn Berry uses a proprietary checksum format that is not compatible with standard SRI hashes or CycloneDX hash algorithms. Components from Yarn Berry lockfiles will be included in the SBOM without integrity hashes. This is a format limitation, not a forgeseal bug.
 
@@ -65,6 +68,15 @@ forgeseal sbom --dir .
 
 # Generate an SBOM from a Python project (uv, poetry, pdm, or pip)
 forgeseal sbom --dir ./my-python-app
+
+# Generate an SBOM from a Go project (go.mod + go.sum)
+forgeseal sbom --dir ./my-go-service
+
+# Generate an SBOM from a Rust project (Cargo.lock)
+forgeseal sbom --dir ./my-rust-crate
+
+# Generate an SBOM from a Gradle project (gradle.lockfile)
+forgeseal sbom --dir ./my-gradle-app
 
 # Full pipeline: SBOM + sign + attest + VEX triage
 forgeseal pipeline --dir . --output-dir ./forgeseal-output --vex-triage

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'forgeseal'
-description: 'Supply chain security for JS/TS: SBOM generation, Sigstore signing, SLSA provenance, VEX triage'
+description: 'Supply chain security for JS/TS, Python, Go, Rust, and Java: SBOM generation, Sigstore signing, SLSA provenance, VEX triage'
 author: 'sns45'
 
 branding:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,8 +13,8 @@ var cfgFile string
 
 var rootCmd = &cobra.Command{
 	Use:   "forgeseal",
-	Short: "Supply chain security for JS/TS projects",
-	Long:  `forgeseal generates CycloneDX SBOMs, signs them with Sigstore, produces SLSA provenance attestations, and manages VEX documents for JavaScript/TypeScript projects.`,
+	Short: "Supply chain security for JS/TS, Python, Go, Rust, and Java projects",
+	Long:  `forgeseal generates CycloneDX SBOMs, signs them with Sigstore, produces SLSA provenance attestations, and manages VEX documents for JavaScript/TypeScript, Python, Go, Rust, and Java/Gradle projects.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/internal/lockfile/parser.go
+++ b/internal/lockfile/parser.go
@@ -101,7 +101,7 @@ func Detect(dir string) (*DetectResult, []string, error) {
 	}
 
 	if len(found) == 0 {
-		return nil, nil, fmt.Errorf("no lockfile found in %s; supported: bun.lockb, bun.lock, pnpm-lock.yaml, yarn.lock, package-lock.json, uv.lock, poetry.lock, pdm.lock, requirements.txt", dir)
+		return nil, nil, fmt.Errorf("no lockfile found in %s; supported: bun.lockb, bun.lock, pnpm-lock.yaml, yarn.lock, package-lock.json, uv.lock, poetry.lock, pdm.lock, requirements.txt, go.mod, Cargo.lock, gradle.lockfile", dir)
 	}
 
 	// Special case: if both bun.lockb and bun.lock exist, prefer bun.lock (no CLI dependency).

--- a/internal/sbom/generator_test.go
+++ b/internal/sbom/generator_test.go
@@ -118,6 +118,76 @@ func TestGeneratorGeneratePyPI(t *testing.T) {
 	}
 }
 
+func TestGeneratorGenerateGo(t *testing.T) {
+	lr := &lockfile.LockfileResult{
+		Type: lockfile.TypeGoMod,
+		Packages: []lockfile.Package{
+			{Name: "github.com/gorilla/mux", Version: "v1.8.1"},
+			{Name: "golang.org/x/sys", Version: "v0.29.0"},
+		},
+	}
+	gen := &Generator{Version: "test"}
+	bom, err := gen.Generate(context.Background(), lr, GenerateOptions{SpecVersion: "1.5", IncludeDev: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bom.Components == nil || len(*bom.Components) != 2 {
+		t.Fatalf("expected 2 components")
+	}
+	for _, comp := range *bom.Components {
+		if len(comp.PackageURL) < 11 || comp.PackageURL[:11] != "pkg:golang/" {
+			t.Errorf("expected pkg:golang/ prefix, got %s", comp.PackageURL)
+		}
+	}
+}
+
+func TestGeneratorGenerateRust(t *testing.T) {
+	lr := &lockfile.LockfileResult{
+		Type: lockfile.TypeCargoLock,
+		Packages: []lockfile.Package{
+			{Name: "serde", Version: "1.0.197"},
+			{Name: "tokio", Version: "1.36.0"},
+		},
+	}
+	gen := &Generator{Version: "test"}
+	bom, err := gen.Generate(context.Background(), lr, GenerateOptions{SpecVersion: "1.5", IncludeDev: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bom.Components == nil || len(*bom.Components) != 2 {
+		t.Fatalf("expected 2 components")
+	}
+	for _, comp := range *bom.Components {
+		if len(comp.PackageURL) < 10 || comp.PackageURL[:10] != "pkg:cargo/" {
+			t.Errorf("expected pkg:cargo/ prefix, got %s", comp.PackageURL)
+		}
+	}
+}
+
+func TestGeneratorGenerateGradle(t *testing.T) {
+	lr := &lockfile.LockfileResult{
+		Type: lockfile.TypeGradleLock,
+		Packages: []lockfile.Package{
+			{Name: "org.springframework:spring-core", Version: "6.1.2"},
+			{Name: "com.google.guava:guava", Version: "32.1.3-jre"},
+			{Name: "org.junit.jupiter:junit-jupiter-api", Version: "5.10.1", Dev: true},
+		},
+	}
+	gen := &Generator{Version: "test"}
+	bom, err := gen.Generate(context.Background(), lr, GenerateOptions{SpecVersion: "1.5", IncludeDev: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bom.Components == nil || len(*bom.Components) != 2 {
+		t.Fatalf("expected 2 components (dev excluded), got %d", len(*bom.Components))
+	}
+	for _, comp := range *bom.Components {
+		if len(comp.PackageURL) < 10 || comp.PackageURL[:10] != "pkg:maven/" {
+			t.Errorf("expected pkg:maven/ prefix, got %s", comp.PackageURL)
+		}
+	}
+}
+
 func TestEcosystemFromLockfileType(t *testing.T) {
 	tests := []struct {
 		lt   lockfile.LockfileType
@@ -133,6 +203,9 @@ func TestEcosystemFromLockfileType(t *testing.T) {
 		{lockfile.TypePoetry, "pypi"},
 		{lockfile.TypePDM, "pypi"},
 		{lockfile.TypeUV, "pypi"},
+		{lockfile.TypeGoMod, "golang"},
+		{lockfile.TypeCargoLock, "cargo"},
+		{lockfile.TypeGradleLock, "maven"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Updates `Detect()` error message to list `go.mod`, `Cargo.lock`, `gradle.lockfile`
- Adds `TestGeneratorGenerateGo/Rust/Gradle` and extends `TestEcosystemFromLockfileType`
- Updates `rootCmd`, `action.yml`, `.goreleaser.yaml`, and `README.md` to reflect the new ecosystems

Closes #14. Rebased onto main after #20 merged (replaces #18).

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `forgeseal sbom --dir testdata/lockfiles/{gomod,cargo,gradle}` each produce valid SBOMs