### PR TITLE
Pull Homebrew tap token from Doppler at release time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # GoReleaser builds cross-platform binaries, the container image, and the GitHub release
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
-          args: release --clean
+          install-only: true
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: GoReleaser release (Homebrew tap token via Doppler)
+        run: doppler run -- goreleaser release --clean
         env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       # Dogfood: full pipeline against reference project + sign the binary
       - name: Build forgeseal for dogfooding


### PR DESCRIPTION
## Summary
- GoReleaser now installs via `install-only: true` and runs under `doppler run -- goreleaser release --clean`, so `HOMEBREW_TAP_GITHUB_TOKEN` is injected at runtime from the `release-tooling/prd` Doppler config instead of being wired in as a raw GitHub secret env var.
- Adds a Doppler CLI install step (`dopplerhq/cli-action@v3`) ahead of the release step.
- Uses the existing `DOPPLER_TOKEN` repo secret (read-only scoped service token); no `--project`/`--config` flags needed.
- The old `HOMEBREW_TAP_GITHUB_TOKEN` GitHub secret is left in place as a fallback and is not deleted.
- No other steps (dogfood/pipeline/self-attest/artifact upload) were touched.

## Test plan
- [ ] Confirm `DOPPLER_TOKEN` secret is configured on the repo with access to `release-tooling/prd`
- [ ] Tag a release (or re-run workflow on an existing tag in a fork/dry run) and confirm GoReleaser publishes the Homebrew tap formula successfully
- [ ] Confirm no secret values are printed in workflow logs